### PR TITLE
dpccp: enumerateCmp descending

### DIFF
--- a/Query Optimization/ikkbz_hist/qoalgo/dpccp.py
+++ b/Query Optimization/ikkbz_hist/qoalgo/dpccp.py
@@ -89,6 +89,9 @@ class Dpccp():
 
         blocked = [r for r in self.qg.relations if self.qg.relations.index(r) <= smallest_index] + csg
         neighbours = [n for n in self.qg.get_neighbours(csg) if n not in blocked]
+
+        neighbours.sort(key=lambda n: n.name, reverse=True)
+
         for n in neighbours:
             yield [n]
             blocked_n = [r for r in self.qg.relations if self.qg.relations.index(r) <= self.qg.relations.index(n)]


### PR DESCRIPTION
According to the pseudo code from the slides the complements should be enumerated descending:
```
EnumerateCmp(G, S_1):
[...]
for all (v_i \in N by **descending** i) { [...] }
```

Using the relation name certainly is not ideal, if you have a better suggestion, that would be excellent.